### PR TITLE
Add documentation for checkout order creation

### DIFF
--- a/docs/IntegrationGuide.md
+++ b/docs/IntegrationGuide.md
@@ -98,7 +98,7 @@ Checkout order with subscriptions contains following custom fields:
 | Name                    | Type    | Description                                                                                                                           | Required |
 | ----------------------- | ------- | ------------------------------------------------------------------------------------------------------------------------------------- | -------- |
 | hasSubscription         | boolean | True if the order contains line items that should be processed as subscriptions                                                       | YES      |
-| isSubscriptionProcessed | boolean | True if the order has already been processed by `commercetools-subscriptions.` This attribute is set by `commercetools-subscriptions` |
+| isSubscriptionProcessed | boolean | True if the order has already been processed by `commercetools-subscriptions.` This attribute is set by `commercetools-subscriptions` | NO       |
 
 ### Checkout line item custom fields
 

--- a/docs/IntegrationGuide.md
+++ b/docs/IntegrationGuide.md
@@ -10,7 +10,7 @@
 
 Create all the required custom types and states located in [resources folder](./resources).  Check [project requirements](./docs/HowToRun.md#commercetools-project-requirements) for more details.
 
-## Step 1: Create checkout order with subscriptions
+## Step 1: Create a checkout order with subscriptions
 
 `commercetools-subscriptions` processes only orders with subscription line items.
 

--- a/docs/IntegrationGuide.md
+++ b/docs/IntegrationGuide.md
@@ -8,7 +8,7 @@
 
 ## Before you begin
 
-Create all the required custom types and states located in [resources folder](./resources).  Check [project requirements](./docs/HowToRun.md#commercetools-project-requirements) for more details.
+Create all the required custom types and states located in [resources folder](./resources). Check [project requirements](./docs/HowToRun.md#commercetools-project-requirements) for more details.
 
 ## Step 1: Create a checkout order with subscriptions
 

--- a/docs/IntegrationGuide.md
+++ b/docs/IntegrationGuide.md
@@ -8,7 +8,7 @@
 
 ## Before you begin
 
-Create all the required custom types and states located in [resources folder](./resources).
+Create all the required custom types and states located in [resources folder](./resources).  Check [project requirements](./docs/HowToRun.md#commercetools-project-requirements) for more details.
 
 ## Step 1: Create checkout order with subscriptions
 

--- a/docs/IntegrationGuide.md
+++ b/docs/IntegrationGuide.md
@@ -52,7 +52,7 @@ the example, there is 1 subscription line item for wine and 1 line item for pant
         "fields": {
           "cutoffDays": 5,
           "reminderDays": 5,
-          "subscriptionKey": "",
+          "subscriptionKey": "UNIQUE_SUBSCRIPTION_KEY",
           "isSubscription": true,
           "schedule": "0 0 1 Feb,May,Aug,Nov *"
         }

--- a/docs/IntegrationGuide.md
+++ b/docs/IntegrationGuide.md
@@ -1,0 +1,117 @@
+# Integration guide
+
+## Terminology
+
+- **checkout-order**: an order which customers create during the checkout. It may contain one or more subscriptions.
+- **template-order**: an order which manages a single subscription and is used as a template to create a
+  subscription-order.
+
+## Before you begin
+
+Create all the required custom types and states located in [resources folder](./resources).
+
+## Step 1: Create checkout order with subscriptions
+
+`commercetools-subscriptions` processes only orders with subscription line items.
+
+<details>
+<summary> Click to expand an example order draft. In
+the example, there is 1 subscription line item for wine and 1 line item for pants</summary>
+
+```
+{
+  "orderNumber": "10000",
+  "customerEmail": "test@test.com",
+  "totalPrice": {
+    "currencyCode": "EUR",
+    "centAmount": 18000
+  },
+  "lineItems": [
+    {
+      "name": {
+        "en": "Wine subscription"
+      },
+      "variant": {
+        "sku": "wine01"
+      },
+      "price": {
+        "value": {
+          "type": "centPrecision",
+          "currencyCode": "EUR",
+          "centAmount": 18000,
+          "fractionDigits": 2
+        },
+        "country": "DE"
+      },
+      "quantity": 1,
+      "custom": {
+        "type": {
+          "typeId": "type",
+          "key": "checkout-order-line-item"
+        },
+        "fields": {
+          "cutoffDays": 5,
+          "reminderDays": 5,
+          "subscriptionKey": "",
+          "isSubscription": true,
+          "schedule": "0 0 1 Feb,May,Aug,Nov *"
+        }
+      }
+    },
+    {
+      "name": {
+        "en": "Pants"
+      },
+      "variant": {
+        "sku": "pants"
+      },
+      "price": {
+        "value": {
+          "type": "centPrecision",
+          "currencyCode": "EUR",
+          "centAmount": 8000,
+          "fractionDigits": 2
+        },
+        "country": "DE"
+      },
+      "quantity": 1
+    }
+  ],
+  "custom": {
+    "type": {
+      "typeId": "type",
+      "key": "checkout-order"
+    },
+    "fields": {
+      "hasSubscription": true
+    }
+  }
+}
+```
+
+</details>
+
+Checkout order with subscriptions contains following custom fields:
+
+### Checkout order custom fields:
+
+| Name                    | Type    | Description                                                                                                                           | Required |
+| ----------------------- | ------- | ------------------------------------------------------------------------------------------------------------------------------------- | -------- |
+| hasSubscription         | boolean | True if the order contains line items that should be processed as subscriptions                                                       | YES      |
+| isSubscriptionProcessed | boolean | True if the order has already been processed by `commercetools-subscriptions.` This attribute is set by `commercetools-subscriptions` |
+
+### Checkout line item custom fields
+
+| Name            | Type    | Description                                                                                                                                                                                             | Required |
+| --------------- | ------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | -------- |
+| isSubscription  | boolean | True if the line item represents a subscription                                                                                                                                                         | YES      |
+| schedule        | String  | Cron syntax which defines the trigger cycle of the subscription-order                                                                                                                                   | YES      |
+| subscriptionKey | String  | It will be used to generate unique orderNumber(s) for the template orders. It has to be unique across all commercetools order API lineItems.                                                            | YES      |
+| reminderDays    | Number  | Defines the amount of days the reminder should be triggered before the next delivery                                                                                                                    | NO       |
+| cutoffDays      | Number  | If the amount of days since placing of the checkout-order until the next scheduled subscription order is equal or smaller than cutoffDays then the next closest subscription-order creation is skipped. | NO       |
+
+cutoffDays: This setting allows omitting scenarios where a customer gets 2 subscription deliveries within a very short period if the checkout-order has been placed shortly before the next scheduled period begins.
+Example: Let's assume we trigger a subscription-order every 1st of February and 1st of May, cutoffDays is set to 15:
+
+- If the checkout-order was placed until 15 of January then the next subscription-order creation is planned for the 1st of February.
+- If the checkout-order was placed between 16 - 31 of January then the next subscription-order creation is planned for the 1st of May.


### PR DESCRIPTION
In this documentation I tried to create a quick guide what the customer should do in order to use [commercetools-subscriptions](https://github.com/commercetools/commercetools-subscriptions). The documentation about how commercetools-subscriptions works underneath is NOT part of this PR, it will be added later.