### PR TITLE
Copy shipping info from checkout order to template order

### DIFF
--- a/src/create-template-orders.js
+++ b/src/create-template-orders.js
@@ -301,6 +301,12 @@ function _generateTemplateOrderImportDraft(
       typeId: 'state',
       key: ACTIVE_STATE,
     },
+    shippingInfo: {
+      shippingMethodName: checkoutOrder.shippingInfo?.shippingMethodName,
+      shippingMethod: checkoutOrder.shippingInfo?.shippingMethod,
+      price: checkoutOrder.shippingInfo?.price,
+      shippingRate: checkoutOrder.shippingInfo?.shippingRate,
+    },
   }
   delete templateOrder.custom.fields.hasSubscription
   return templateOrder

--- a/src/create-template-orders.js
+++ b/src/create-template-orders.js
@@ -287,7 +287,12 @@ function _generateTemplateOrderImportDraft(
       typeId: 'state',
       id: activeStateId,
     },
-    shippingInfo: checkoutOrder.shippingInfo,
+    shippingInfo: {
+      shippingMethodName: checkoutOrder.shippingInfo?.shippingMethodName,
+      shippingMethod: checkoutOrder.shippingInfo?.shippingMethod,
+      price: checkoutOrder.shippingInfo?.price,
+      shippingRate: checkoutOrder.shippingInfo?.shippingRate,
+    },
   }
   delete templateOrder.custom.fields.hasSubscription
   return templateOrder

--- a/src/create-template-orders.js
+++ b/src/create-template-orders.js
@@ -287,12 +287,7 @@ function _generateTemplateOrderImportDraft(
       typeId: 'state',
       id: activeStateId,
     },
-    shippingInfo: {
-      shippingMethodName: checkoutOrder.shippingInfo?.shippingMethodName,
-      shippingMethod: checkoutOrder.shippingInfo?.shippingMethod,
-      price: checkoutOrder.shippingInfo?.price,
-      shippingRate: checkoutOrder.shippingInfo?.shippingRate,
-    },
+    shippingInfo: checkoutOrder.shippingInfo,
   }
   delete templateOrder.custom.fields.hasSubscription
   return templateOrder

--- a/test/integration/create-template-orders.spec.js
+++ b/test/integration/create-template-orders.spec.js
@@ -91,17 +91,8 @@ describe('create-template-orders', () => {
       )
       expect(templateOrder.customerGroup).to.equal(checkoutOrder.customerGroup)
       expect(templateOrder.country).to.equal(checkoutOrder.country)
-      expect(templateOrder.shippingInfo.price).to.deep.equal(
-        checkoutOrder.shippingInfo.price
-      )
-      expect(templateOrder.shippingInfo.shippingMethod).to.deep.equal(
-        checkoutOrder.shippingInfo.shippingMethod
-      )
-      expect(templateOrder.shippingInfo.shippingRate).to.deep.equal(
-        checkoutOrder.shippingInfo.shippingRate
-      )
-      expect(templateOrder.shippingInfo.shippingMethodName).to.deep.equal(
-        checkoutOrder.shippingInfo.shippingMethodName
+      expect(templateOrder.shippingInfo).to.deep.equal(
+        checkoutOrder.shippingInfo
       )
       expect(templateOrder.taxMode).to.equal(checkoutOrder.taxMode)
       expect(templateOrder.inventoryMode).to.equal('None')

--- a/test/integration/create-template-orders.spec.js
+++ b/test/integration/create-template-orders.spec.js
@@ -84,7 +84,18 @@ describe('create-template-orders', () => {
       )
       expect(templateOrder.customerGroup).to.equal(checkoutOrder.customerGroup)
       expect(templateOrder.country).to.equal(checkoutOrder.country)
-      expect(templateOrder.shippingInfo).to.equal(checkoutOrder.shippingInfo)
+      expect(templateOrder.shippingInfo.price).to.deep.equal(
+        checkoutOrder.shippingInfo.price
+      )
+      expect(templateOrder.shippingInfo.shippingMethod).to.deep.equal(
+        checkoutOrder.shippingInfo.shippingMethod
+      )
+      expect(templateOrder.shippingInfo.shippingRate).to.deep.equal(
+        checkoutOrder.shippingInfo.shippingRate
+      )
+      expect(templateOrder.shippingInfo.shippingMethodName).to.deep.equal(
+        checkoutOrder.shippingInfo.shippingMethodName
+      )
       expect(templateOrder.taxMode).to.equal(checkoutOrder.taxMode)
       expect(templateOrder.inventoryMode).to.equal('None')
     })

--- a/test/integration/create-template-orders.spec.js
+++ b/test/integration/create-template-orders.spec.js
@@ -91,8 +91,17 @@ describe('create-template-orders', () => {
       )
       expect(templateOrder.customerGroup).to.equal(checkoutOrder.customerGroup)
       expect(templateOrder.country).to.equal(checkoutOrder.country)
-      expect(templateOrder.shippingInfo).to.deep.equal(
-        checkoutOrder.shippingInfo
+      expect(templateOrder.shippingInfo.price).to.deep.equal(
+        checkoutOrder.shippingInfo.price
+      )
+      expect(templateOrder.shippingInfo.shippingMethod).to.deep.equal(
+        checkoutOrder.shippingInfo.shippingMethod
+      )
+      expect(templateOrder.shippingInfo.shippingRate).to.deep.equal(
+        checkoutOrder.shippingInfo.shippingRate
+      )
+      expect(templateOrder.shippingInfo.shippingMethodName).to.deep.equal(
+        checkoutOrder.shippingInfo.shippingMethodName
       )
       expect(templateOrder.taxMode).to.equal(checkoutOrder.taxMode)
       expect(templateOrder.inventoryMode).to.equal('None')

--- a/test/integration/test-utils.js
+++ b/test/integration/test-utils.js
@@ -29,17 +29,21 @@ const templateOrderDraft = await readAndParseJsonFile(
   'test/resources/template-order-draft.json'
 )
 
+let shippingMethodId
+let taxCategoryId
+
 async function ensureResources(apiRoot, logger) {
   await ensureCustomTypes(apiRoot, logger)
   await ensureStates(apiRoot, logger)
   const zone = await ensureZones(apiRoot)
   const taxCategory = await ensureTaxCategories(apiRoot)
+  taxCategoryId = taxCategory.id
   const shippingMethodsResponse = await ensureShippingMethod(
     apiRoot,
     zone.id,
     taxCategory.id
   )
-  const shippingMethodId = shippingMethodsResponse.id
+  shippingMethodId = shippingMethodsResponse.id
   await ensureProductType(apiRoot)
   const productsResponse = await ensureProducts(apiRoot)
   return {
@@ -110,7 +114,7 @@ async function ensureTaxCategories(apiRoot) {
   return taxCategory
 }
 
-async function ensureShippingMethod(apiRoot, zoneId, taxCategoryId) {
+async function ensureShippingMethod(apiRoot, zoneId) {
   let {
     body: {
       results: [shippingMethod],
@@ -231,6 +235,8 @@ async function createOrder(
     logger.debug(
       `About to create order in test project with orderNumber ${orderDraft.orderNumber}`
     )
+    orderDraft.shippingInfo.taxCategory.id = taxCategoryId
+    orderDraft.shippingInfo.shippingMethod.id = shippingMethodId
     const { body } = await apiRoot
       .orders()
       .importOrder()

--- a/test/resources/order-draft.json
+++ b/test/resources/order-draft.json
@@ -95,5 +95,61 @@
     "fields": {
       "hasSubscription": true
     }
+  },
+  "shippingInfo": {
+    "shippingMethodName": "de",
+    "price": {
+      "type": "centPrecision",
+      "currencyCode": "EUR",
+      "centAmount": 0,
+      "fractionDigits": 2
+    },
+    "shippingRate": {
+      "price": {
+        "type": "centPrecision",
+        "currencyCode": "EUR",
+        "centAmount": 790,
+        "fractionDigits": 2
+      },
+      "freeAbove": {
+        "type": "centPrecision",
+        "currencyCode": "EUR",
+        "centAmount": 9900,
+        "fractionDigits": 2
+      },
+      "tiers": []
+    },
+    "taxRate": {
+      "name": "de",
+      "amount": 0.19,
+      "includedInPrice": true,
+      "country": "DE",
+      "id": "r1yayG-u",
+      "subRates": []
+    },
+    "taxCategory": {
+      "typeId": "tax-category",
+      "id": "7961b321-aeca-4f5b-9542-67d17667271d"
+    },
+    "deliveries": [],
+    "shippingMethod": {
+      "typeId": "shipping-method",
+      "id": "e81c0e3c-5456-4f84-abb9-3f138a80db29"
+    },
+    "taxedPrice": {
+      "totalNet": {
+        "type": "centPrecision",
+        "currencyCode": "EUR",
+        "centAmount": 0,
+        "fractionDigits": 2
+      },
+      "totalGross": {
+        "type": "centPrecision",
+        "currencyCode": "EUR",
+        "centAmount": 0,
+        "fractionDigits": 2
+      }
+    },
+    "shippingMethodState": "MatchesCart"
   }
 }

--- a/test/resources/template-order-draft.json
+++ b/test/resources/template-order-draft.json
@@ -100,6 +100,62 @@
       "schedule": "0 0 1 Feb,May,Aug,Nov *"
     }
   },
+  "shippingInfo": {
+    "shippingMethodName": "de",
+    "price": {
+      "type": "centPrecision",
+      "currencyCode": "EUR",
+      "centAmount": 0,
+      "fractionDigits": 2
+    },
+    "shippingRate": {
+      "price": {
+        "type": "centPrecision",
+        "currencyCode": "EUR",
+        "centAmount": 790,
+        "fractionDigits": 2
+      },
+      "freeAbove": {
+        "type": "centPrecision",
+        "currencyCode": "EUR",
+        "centAmount": 9900,
+        "fractionDigits": 2
+      },
+      "tiers": []
+    },
+    "taxRate": {
+      "name": "de",
+      "amount": 0.19,
+      "includedInPrice": true,
+      "country": "DE",
+      "id": "r1yayG-u",
+      "subRates": []
+    },
+    "taxCategory": {
+      "typeId": "tax-category",
+      "id": "7961b321-aeca-4f5b-9542-67d17667271d"
+    },
+    "deliveries": [],
+    "shippingMethod": {
+      "typeId": "shipping-method",
+      "id": "e81c0e3c-5456-4f84-abb9-3f138a80db29"
+    },
+    "taxedPrice": {
+      "totalNet": {
+        "type": "centPrecision",
+        "currencyCode": "EUR",
+        "centAmount": 0,
+        "fractionDigits": 2
+      },
+      "totalGross": {
+        "type": "centPrecision",
+        "currencyCode": "EUR",
+        "centAmount": 0,
+        "fractionDigits": 2
+      }
+    },
+    "shippingMethodState": "MatchesCart"
+  },
   "itemShippingAddresses": [],
   "refusedGifts": []
 }


### PR DESCRIPTION
As discussed internally, we should also copy the shippingInfo from checkout order to template order. This PR does exactly that.