### PR TITLE
Add shippingInfo only if exists

### DIFF
--- a/src/create-template-orders.js
+++ b/src/create-template-orders.js
@@ -288,12 +288,13 @@ function _generateTemplateOrderImportDraft(
       id: activeStateId,
     },
   }
-  if (checkoutOrder.shippingInfo)
+  const shippingInfo = checkoutOrder.shippingInfo
+  if (shippingInfo)
     templateOrder.shippingInfo = {
-      shippingMethodName: checkoutOrder.shippingInfo?.shippingMethodName,
-      shippingMethod: checkoutOrder.shippingInfo?.shippingMethod,
-      price: checkoutOrder.shippingInfo?.price,
-      shippingRate: checkoutOrder.shippingInfo?.shippingRate,
+      shippingMethodName: shippingInfo.shippingMethodName,
+      shippingMethod: shippingInfo.shippingMethod,
+      price: shippingInfo.price,
+      shippingRate: shippingInfo.shippingRate,
     }
   delete templateOrder.custom.fields.hasSubscription
   return templateOrder

--- a/src/create-template-orders.js
+++ b/src/create-template-orders.js
@@ -286,7 +286,7 @@ function _generateTemplateOrderImportDraft(
     state: {
       typeId: 'state',
       id: activeStateId,
-    }
+    },
   }
   if (checkoutOrder.shippingInfo)
     templateOrder.shippingInfo = {

--- a/src/create-template-orders.js
+++ b/src/create-template-orders.js
@@ -286,14 +286,15 @@ function _generateTemplateOrderImportDraft(
     state: {
       typeId: 'state',
       id: activeStateId,
-    },
-    shippingInfo: {
+    }
+  }
+  if (checkoutOrder.shippingInfo)
+    templateOrder.shippingInfo = {
       shippingMethodName: checkoutOrder.shippingInfo?.shippingMethodName,
       shippingMethod: checkoutOrder.shippingInfo?.shippingMethod,
       price: checkoutOrder.shippingInfo?.price,
       shippingRate: checkoutOrder.shippingInfo?.shippingRate,
-    },
-  }
+    }
   delete templateOrder.custom.fields.hasSubscription
   return templateOrder
 }


### PR DESCRIPTION
We should add shippingInfo to template order when it exists in the checkout order. Current implementation works fine, but it might be confusing, so I made this change.